### PR TITLE
Fix vertical centering logic

### DIFF
--- a/src/main/java/uk/co/jamesj999/sonic/sprites/AbstractSprite.java
+++ b/src/main/java/uk/co/jamesj999/sonic/sprites/AbstractSprite.java
@@ -76,10 +76,10 @@ public abstract class AbstractSprite implements Sprite {
 		this.xSubpixel = (short) 0;
 	}
 
-	public void setCentreY(short y) {
-		this.yPixel = (short) (y + (width / 2));
-		this.ySubpixel = (short) 0;
-	}
+       public void setCentreY(short y) {
+               this.yPixel = (short) (y - (height / 2));
+               this.ySubpixel = (short) 0;
+       }
 
 	public final short getX() {
 		// TODO Not sure if this is needed, round to nearest subpixel?


### PR DESCRIPTION
## Summary
- use sprite height when centering vertically

## Testing
- `mvn test` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847053bc3308331b65ba3241bbd959a